### PR TITLE
Make the kerberos monkey-patch python3 ready

### DIFF
--- a/jenkins_jobs/urllib_kerb.py
+++ b/jenkins_jobs/urllib_kerb.py
@@ -52,7 +52,7 @@ class HTTPNegotiateHandler(BaseHandler):
 
             self.tries += 1
             try:
-                krb_resp = self._krb_response(req.get_host(), krb_req)
+                krb_resp = self._krb_response(req.host, krb_req)
 
                 req.add_unredirected_header('Authorization',
                                             "Negotiate %s" % krb_resp)


### PR DESCRIPTION
urllib.reqeust.Request.get_host() is removed in python >=3.4 in favor of
urllib.reqeust.Request.host. This works in python 2.X too.
